### PR TITLE
Use a connection pool

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -25,3 +25,5 @@ targets:
 dependencies:
   protobuf:
     github: jeromegn/protobuf.cr
+  db:
+    github: crystal-lang/crystal-db

--- a/src/twirp/client.cr
+++ b/src/twirp/client.cr
@@ -1,46 +1,43 @@
 require "http/client"
+require "db/pool"
 
 require "./error"
 
 module Twirp
   class Client(T)
-    @callback : (HTTP::Request ->)?
+    @callback : HTTP::Request -> = Proc(HTTP::Request, Nil).new { }
 
     def initialize(@uri : URI)
       @prefix = uri.path.presence || "/twirp"
+      @pool = DB::Pool(HTTP::Client).new do
+        http = HTTP::Client.new(@uri)
+        http.before_request { |req| @callback.call req }
+        http
+      end
     end
 
     # Adds a callback to execute before each request (see `HTTP::Client#before_request`)
-    def before_request(&callback : HTTP::Request ->) : Nil
-      @callback = callback
+    def before_request(&@callback : HTTP::Request ->) : Nil
     end
 
     def call(rpc_name, request, response_type)
-      response = HTTP::Client.new(@uri) do |client|
-        if cb = @callback
-          client.before_request(&cb)
+      path = "#{@prefix}/#{T.service_name}/#{rpc_name}"
+      headers = HTTP::Headers{"Content-Type" => "application/protobuf"}
+      @pool.checkout do |http|
+        http.post(path, headers: headers, body: request.to_protobuf) do |response|
+          case response.content_type
+          when "application/json"
+            begin
+              raise Twirp::Error.from_json(response.body_io)
+            rescue err : JSON::SerializableError
+              raise Twirp::Error.new("Failed to parse JSON response: #{err}")
+            end
+          when "application/protobuf"
+            response_type.from_protobuf(response.body_io)
+          else
+            raise Twirp::Error.new("Unexpected response Content-Type: #{response.content_type}")
+          end
         end
-        client.post("#{@prefix}/#{T.service_name}/#{rpc_name}",
-          headers: HTTP::Headers{"Content-Type" => "application/protobuf"},
-          body: request.to_protobuf,
-        )
-      end
-
-      unless body = response.body?
-        raise Twirp::Error::Malformed.new("Failed to read response body")
-      end
-
-      case response.content_type
-      when "application/json"
-        begin
-          raise Twirp::Error.from_json(body)
-        rescue err : JSON::SerializableError
-          raise Twirp::Error.new("Failed to parse JSON response: #{err}")
-        end
-      when "application/protobuf"
-        response_type.from_protobuf(IO::Memory.new(body))
-      else
-        raise Twirp::Error.new("Unexpected response Content-Type: #{response.content_type}")
       end
     end
   end


### PR DESCRIPTION
I noticed in ce721802a5cee716d97a64d05563efc5d0962fc5 there was mention of a desire for a connection pool. The `crystal-lang/crystal-db` shard is capable of managing pools of arbitrary connection types, including `HTTP::Client`s — really, anything with a `close` method).

This commit adds `DB::Pool` for a thread-safe, configurable connection pool. By default, it spins up a single connection on instantiation and will close all but one connection on checking connections back into the pool. This commit does _not_ add configurability to that connection pool, but it can be added in a followup commit.

`DB::Pool` is used in several of my own shards that implement network clients:

- https://github.com/jgaskins/kubernetes
- https://github.com/jgaskins/redis
- https://github.com/jgaskins/aws
- https://github.com/jgaskins/elasticsearch
- https://github.com/jgaskins/neo4j.cr (this actually uses a copy/pasted version of `DB::Pool`, which was the catalyst for https://github.com/crystal-lang/crystal-db/pull/131 enabling this functionality)

A couple other minor touches in this commit include:

- removing a `nil` check on `@callback`
- explicit assignment of that callback in `before_request`, favoring assignment from within the method signature
- parsing JSON/Protobuf directly from the socket instead of reading the full body into memory, avoiding having multiple representations of the response in memory at once

These would've been separate PRs, but they would not have been able to be done concurrently due to merge conflicts so I shoveled them all in here. :smile: